### PR TITLE
compilation fix for VS2015

### DIFF
--- a/project/configs/openal_config.h
+++ b/project/configs/openal_config.h
@@ -72,7 +72,9 @@
 
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
+#if defined(_MSC_VER) && _MSC_VER <1900
 #define snprintf _snprintf
+#endif
 //#define isfinite _finite
 //#define isnan _isnan
 


### PR DESCRIPTION
snprintf is already defined in VS2015 (_MSC_VER == 1900). 
See reference http://stackoverflow.com/questions/27754492/vs-2015-compiling-cocos2d-x-3-3-error-fatal-error-c1189-error-macro-definiti